### PR TITLE
Переименовать раздел "Иное" в "Другое"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ menu:
     url: /using-tiles/
   - title: Делаем свои тайлы
     url: /serving-tiles/
-  - title: Иное
+  - title: Другое
     url: /other-uses/
   - title: Провайдеры
     url: /providers/

--- a/other-uses.md
+++ b/other-uses.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Иное использование
+title: Другое использование
 permalink: /other-uses/
 ---
 


### PR DESCRIPTION
Меня смутило слово "Иное" в шапке страницы. Может стоит заменить на более употребимое слово "Другое"?